### PR TITLE
set hide-on-close property

### DIFF
--- a/data/ui/window.blp
+++ b/data/ui/window.blp
@@ -80,6 +80,7 @@ Adw.Window connect_window {
 }
 
 Adw.AboutWindow about {
+  hide-on-close: true;
   license-type: gpl_3_0;
   copyright: "© 2023 Lars Mühmel";
   website: "https://github.com/BurNiinTRee/cba-midi";


### PR DESCRIPTION
this fixes #7.

Without this property set, closing the window
destroys relevant resources, preventing us
from reusing it. Alternatively one could
also recreate the about window
